### PR TITLE
Make this project works for all SSG frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,3 @@
-# Rspress Plugins
+# SSG Framework Plugins
 
-A collection of plugins to extend the capabilities of [rspress](https://rspress.dev/).
-
-## Plugin List
-
-### Syntax
-
-- [rspress-plugin-supersub](./packages/rspress-plugin-supersub), superscript and subscript syntax support.
-- [rspress-plugin-katex](./packages/rspress-plugin-katex), render math formulas with KaTeX.
-
-### Code Transformers
-
-- [rspress-plugin-mermaid](./packages/rspress-plugin-mermaid), render diagrams with Mermaid.
-- [rspress-plugin-file-tree](./packages/rspress-plugin-file-tree), render file tree as a tree view.
-
-### Extension
-
-- [rspress-plugin-directives](./packages/rspress-plugin-directives), custom directives support.
-
-### Themes
-
-- [rspress-plugin-live2d](./packages/rspress-plugin-live2d), add live2d model to your site.
-- [rspress-plugin-toc](./packages/rspress-plugin-toc), generate table of contents for your pages.
-- [rspress-plugin-reading-time](./packages/rspress-plugin-reading-time), calculate and display reading time for your pages.
-
-### Site
-
-- [rspress-plugin-google-analytics](./packages/rspress-plugin-google-analytics), integrate Google Analytics in your site.
-- [rspress-plugin-vercel-analytics](./packages/rspress-plugin-vercel-analytics), integrate Vercel Analytics in your site.
-- [ ] rspress-plugin-sitemap
-- [ ] rspress-plugin-pwa
-
-### Deploy
-
-- [rspress-plugin-gh-pages](./packages/rspress-plugin-gh-pages), deploy your site to GitHub Pages without pushing.
+A collection of plugins to extend the capabilities of [rspress](https://rspress.dev/), [vitepress](https://vitepress.dev/), and other static site generators.


### PR DESCRIPTION
What we provided in this project could serve for more than rspress, like all remark based SSG frameworks.

This PR will extract the core remark plugin into a new package and, make all plugins works on top of them.