### PR TITLE
ci: add docs:build step to test workflows

### DIFF
--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -43,5 +43,8 @@ jobs:
       - name: Build Packages
         run: pnpm run build
 
+      - name: Build Docs
+        run: pnpm run docs:build
+
       - name: Unit Test
         run: pnpm run test

--- a/.github/workflows/test-macOS.yml
+++ b/.github/workflows/test-macOS.yml
@@ -43,5 +43,8 @@ jobs:
       - name: Build Packages
         run: pnpm run build
 
+      - name: Build Docs
+        run: pnpm run docs:build
+
       - name: Unit Test
         run: pnpm run test

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "commit": "git add -A && czg",
     "packages:build": "pnpm -r --filter=./packages/**/* run build",
     "packages:build:p": "pnpm --parallel --filter=./packages/**/* run build",
+    "docs:build": "pnpm -r --filter=./packages/**/* run docs:build",
     "test": "vitest",
     "testu": "vitest --update",
     "test:cov": "vitest --coverage",


### PR DESCRIPTION
## Summary

Add `docs:build` script to package.json and include docs build step in both Windows and macOS test workflows.

## Changes

- Add `docs:build` script in `package.json` that runs `pnpm -r --filter=./packages/**/* run docs:build`
- Add "Build Docs" step in `.github/workflows/test-Windows.yml`
- Add "Build Docs" step in `.github/workflows/test-macOS.yml`

This ensures all workspace documentation can be built successfully during CI tests.