### PR TITLE
fix(plugin-file-tree): add horizontal padding to comment style

### DIFF
--- a/packages/rspress-plugin-file-tree/src/components/FileTree/FileTreeItem.module.less
+++ b/packages/rspress-plugin-file-tree/src/components/FileTree/FileTreeItem.module.less
@@ -53,6 +53,7 @@
 
 .comment {
   margin-left: 8px;
+  padding: 0 4px;
   color: var(--rp-c-text-2);
   font-style: italic;
   white-space: nowrap;


### PR DESCRIPTION
## Summary

<!-- This is the area edited by humans. -->

## Related issues


## AI Summary

---

### Changes Made
- Added `padding: 0 4px;` to the `.comment` class in `FileTreeItem.module.less`

### Why
- The comment text in the file tree component was too close to adjacent elements
- Adding 4px horizontal padding on both left and right sides improves visual spacing and readability

### Implementation Details
- Modified `packages/rspress-plugin-file-tree/src/components/FileTree/FileTreeItem.module.less:56`
- The padding is applied symmetrically (0 vertical, 4px horizontal)

This PR was written using [Vibe Kanban](https://vibekanban.com)

---