### PR TITLE
fix(plugin-file-tree): fix 2-space indentation parsing for deeply nested tree structures

### DIFF
--- a/packages/rspress-plugin-file-tree/tests/parser.spec.ts
+++ b/packages/rspress-plugin-file-tree/tests/parser.spec.ts
@@ -897,3 +897,66 @@ doc_build
   expect(ellipsis2.name).toBe('...');
   expect(ellipsis2.type).toBe('file');
 });
+
+test('Should parse docs structure with basic directory containing mdx files', () => {
+  const input = `
+docs
+├── _meta.json
+└── guides
+  ├── _meta.json
+  └── basic
+    ├── introduction.mdx
+    ├── install.mdx
+    └── plugin-development.md
+`;
+
+  const result = parseTreeContent(input).nodes;
+
+  // docs is the root directory
+  const docs = result[0];
+  expect(docs.name).toBe('docs');
+  expect(docs.type).toBe('directory');
+  expect(docs.children.length).toBe(2);
+
+  // _meta.json at root level
+  const metaJson = docs.children[0];
+  expect(metaJson.name).toBe('_meta.json');
+  expect(metaJson.type).toBe('file');
+  expect(metaJson.extension).toBe('json');
+
+  // guides directory
+  const guides = docs.children[1];
+  expect(guides.name).toBe('guides');
+  expect(guides.type).toBe('directory');
+  expect(guides.children.length).toBe(2);
+
+  // _meta.json in guides
+  const guidesMetaJson = guides.children[0];
+  expect(guidesMetaJson.name).toBe('_meta.json');
+  expect(guidesMetaJson.type).toBe('file');
+  expect(guidesMetaJson.extension).toBe('json');
+
+  // basic directory (should be a directory, not a file)
+  const basic = guides.children[1];
+  expect(basic.name).toBe('basic');
+  expect(basic.type).toBe('directory');
+  expect(basic.children.length).toBe(3);
+
+  // introduction.mdx
+  const introduction = basic.children[0];
+  expect(introduction.name).toBe('introduction.mdx');
+  expect(introduction.type).toBe('file');
+  expect(introduction.extension).toBe('mdx');
+
+  // install.mdx
+  const install = basic.children[1];
+  expect(install.name).toBe('install.mdx');
+  expect(install.type).toBe('file');
+  expect(install.extension).toBe('mdx');
+
+  // plugin-development.md
+  const pluginDev = basic.children[2];
+  expect(pluginDev.name).toBe('plugin-development.md');
+  expect(pluginDev.type).toBe('file');
+  expect(pluginDev.extension).toBe('md');
+});


### PR DESCRIPTION
## Summary

<!-- This is the area edited by humans. -->

## Related issues


## AI Summary

---

### What changes were made

1. **Added `detectIndentSize()` function** - Scans all lines to detect whether the tree uses 2-space or 4-space indentation mode
2. **Updated `calculateIndent()` function** - Now accepts an `indentSize` parameter to correctly calculate indent levels based on the detected mode
3. **Added comprehensive test case** - Tests a docs structure with 3-level nesting using 2-space indentation

### Why they were made

The original tree parser had a bug when handling 2-space indented trees with 3 or more nesting levels. For example:

\`\`\`tree
docs
├── _meta.json
└── guides
  ├── _meta.json
  └── basic
    ├── introduction.mdx
    ├── install.mdx
    └── plugin-development.md
\`\`\`

The files under \`basic\` directory (4 spaces = 2+2) were incorrectly placed as siblings of \`basic\` instead of children, because the algorithm treated 4 spaces as a single 4-space indent unit rather than two 2-space units.

### Implementation details

- The fix detects indentation mode by looking for lines with exactly 2 spaces before branch characters (\`├──\` or \`└──\`)
- Once 2-space mode is detected, all space-based indentation is calculated in 2-space units
- This ensures \`    ├── file.mdx\` (4 spaces) is correctly calculated as indent level 3 (2 units of 2-space + branch) instead of indent level 2

This PR was written using [Vibe Kanban](https://vibekanban.com)

---