### PR TITLE
fix(katex): resolve ReferenceError require is not defined in ESM

### DIFF
--- a/packages/rspress-plugin-katex/src/index.ts
+++ b/packages/rspress-plugin-katex/src/index.ts
@@ -11,6 +11,7 @@ export interface RspressPluginKatexOptions
 
 import { visit } from 'unist-util-visit';
 import type { Plugin } from 'unified';
+import { createRequire } from 'node:module';
 
 const remarkCodeBlockToMath: Plugin = () => {
   return (tree) => {
@@ -30,6 +31,7 @@ const remarkCodeBlockToMath: Plugin = () => {
 export default function rspressPluginKatex(
   options: RspressPluginKatexOptions = {},
 ): RspressPlugin {
+  const require = createRequire(import.meta.url);
   const katexCss = require.resolve('katex/dist/katex.min.css');
 
   return {


### PR DESCRIPTION
### What is the purpose of this PR?
Fix a `ReferenceError` when using this plugin in a strict Node.js ESM environment

### What is the issue?
The source code mixes ESM `import` statements with CommonJS `require.resolve()`. When the plugin is compiled to an ES Module and executed in Node.js, the global `require` object does not exist, causing a runtime crash:
`ReferenceError: require is not defined`

### How does it fix?
Imported `createRequire` from `node:module` to safely construct a `require` function using `import.meta.url`, which correctly resolves the path of `katex.min.css` in both ESM and bundler environments.